### PR TITLE
Add test test_alertmanager_ha and small fix

### DIFF
--- a/stacklight_tests/tests/prometheus/test_smoke.py
+++ b/stacklight_tests/tests/prometheus/test_smoke.py
@@ -16,8 +16,7 @@ class TestPrometheusSmoke(object):
 
 
 class TestAlertmanagerSmoke(object):
-    def test_alertmanager_endpoint_availability(self, cluster,
-                                                prometheus_config):
+    def test_alertmanager_endpoint_availability(self, prometheus_config):
         """Check that alertmanager endpoint is available.
 
         Scenario:
@@ -26,13 +25,32 @@ class TestAlertmanagerSmoke(object):
         Duration 1m
         """
         port = int(prometheus_config["prometheus_alertmanager"])
-        cfg = [host for host in cluster.hosts
-               if host.fqdn.startswith("cfg")][0].address
+        alertmanager_ip = prometheus_config["prometheus_vip"]
         try:
             s = socket.socket()
-            s.connect((cfg, port))
+            s.connect((alertmanager_ip, port))
             s.close()
             result = True
         except socket.error:
             result = False
         assert result
+
+    def test_alertmanager_ha(self, cluster, prometheus_config):
+        """Check alertmanager HA .
+
+        Scenario:
+            1. Stop 1 alertmanager replic
+            2. Get alertmanager endpoint
+            3. Check that alertmanager endpoint is available
+        Duration 1m
+        """
+        prometheus_nodes = cluster.filter_by_role("prometheus")
+        for host in prometheus_nodes:
+            alertmanager_docker_id = host.exec_command(
+                "docker ps | grep alertmanager | awk '{print $1}'")
+            if alertmanager_docker_id:
+                command = "docker kill " + str(alertmanager_docker_id)
+                host.exec_command(command)
+                return TestAlertmanagerSmoke. \
+                    test_alertmanager_endpoint_availability(self,
+                                                            prometheus_config)


### PR DESCRIPTION
Addind test 'test_alertmanager_ha' to the 'prometheus.test_smoke.py'
Adding fix to the 'test_alertmanager_endpoint_availability' to the
'prometheus.test_smoke.py'
Fix is about using 'prometheus_vip' instead of 'cfg01 ip' for the promethues
server