### PR TITLE
Alignt requirements to openstack global

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,15 +6,16 @@ pika>=0.10.0 # BSD License
 pytest>=3.0.4  # MIT
 python-ceilometerclient>=2.5.0  # Apache-2.0
 python-cinderclient>=1.6.0,!=1.7.0,!=1.7.1  # Apache-2.0
-python-glanceclient>=2.3.0,!=2.4.0  # Apache-2.0
-python-heatclient>=1.4.0  # Apache-2.0
-python-keystoneclient>=2.0.0,!=2.1.0  # Apache-2.0
+python-glanceclient>=2.5.0  # Apache-2.0
+python-heatclient>=1.6.1  # Apache-2.0
+python-keystoneclient>=3.8.0  # Apache-2.0
 python-muranoclient>=0.8.2  # Apache-2.0
 python-neutronclient>=5.1.0  # Apache-2.0
-python-novaclient>=2.29.0,!=2.33.0  # Apache-2.0
-python-saharaclient>=0.18.0  # Apache-2.0
+python-novaclient>=6.0.0,!=7.0.0  # Apache-2.0
+python-saharaclient>=1.1.0  # Apache-2.0
 PyYAML>=3.12  # MIT
-requests>=2.10.0  # Apache-2.0
+requests>=2.10.0,!=2.12.2 # Apache-2.0
 six>=1.10.0  # MIT
 tox>=2.5.0  # MIT
+urllib3>=1.15.1
 warlock!=1.3.0,<2,>=1.0.1


### PR DESCRIPTION
Curently gen-config fails due to urllib version conflicts.
So lets align requirements to  openstack global