### PR TITLE
Make volume state configurable

### DIFF
--- a/stacklight_tests/settings.py
+++ b/stacklight_tests/settings.py
@@ -17,3 +17,5 @@ CIRROS_QCOW2_URL = os.environ.get(
 
 CONFIGURE_APPS = ["nodes", "influxdb", "elasticsearch", "grafana",
                   "nagios", "keystone", "mysql", "prometheus"]
+
+VOLUME_STATUS = os.environ.get("VOLUME_STATUS", "error")


### PR DESCRIPTION
* Make expected volume state configurable
  to avoid false negative result on envs where
  cinder-volume exists

* Change queries for openstack metrics test
  Curently there is no state param/fiels if we use openstack_service in query

* Leave only openstack_nova_instances{' + 'state="{}"' in telegraf_metrics cheks

Add check in check_openstack_metrics() that if output is empty, need to check the queris,
to avoid index errors