### PR TITLE
Add process runing checks for influxdb

### DIFF
--- a/stacklight_tests/clients/fixtures.py
+++ b/stacklight_tests/clients/fixtures.py
@@ -54,13 +54,13 @@ def nagios_client(nagios_config):
 
 
 @pytest.fixture(scope="session")
-def influxdb_client(config):
+def influxdb_client(influxdb_config):
     influxdb = influxdb_api.InfluxdbApi(
-        address=config["influxdb_vip"],
-        port=config["influxdb_port"],
-        username=config["influxdb_username"],
-        password=config["influxdb_password"],
-        db_name=config["influxdb_db_name"]
+        address=influxdb_config["influxdb_vip"],
+        port=influxdb_config["influxdb_port"],
+        username=influxdb_config["influxdb_username"],
+        password=influxdb_config["influxdb_password"],
+        db_name=influxdb_config["influxdb_db_name"]
     )
     return influxdb
 

--- a/stacklight_tests/clients/influxdb_api.py
+++ b/stacklight_tests/clients/influxdb_api.py
@@ -167,7 +167,7 @@ class InfluxdbApi(object):
             raise custom_exceptions.TimeoutError(e)
 
     def get_environment_name(self):
-        query = "show tag values from cpu_idle with key = environment_label"
+        query = "show tag values from cpu_usage_idle with key = host"
         return self.do_influxdb_query(
             query).json()["results"][0]["series"][0]["values"][0][1]
 

--- a/stacklight_tests/tests/prometheus/test_influxdb_smoke.py
+++ b/stacklight_tests/tests/prometheus/test_influxdb_smoke.py
@@ -1,0 +1,51 @@
+import pytest
+
+
+def check_service_installed(cluster, name, role=None):
+    """Checks that service is installed on nodes with provided role."""
+    if role is None:
+        role = "monitoring"
+    nodes = cluster.filter_by_role(role)
+    for node in nodes:
+        node.os.check_package_installed(name)
+
+
+def check_service_running(cluster, name, role=None):
+    """Checks that service is running on nodes with provided role."""
+    if role is None:
+        role = "monitoring"
+    nodes = cluster.filter_by_role(role)
+    for node in nodes:
+        node.os.manage_service(name, "status")
+
+
+class TestInfluxDbSmoke(object):
+
+    def test_influxdb_installed(self, cluster, influxdb_client):
+        """Smoke test that checks basic features of InfluxDb.
+
+        Scenario:
+            1. Check InfluxDB package is installed
+            2. Check InfluxDB is up and running
+            3. Check that InfluxDB is online and can serve requests
+
+        Duration 1m
+        """
+        service = "influxdb"
+        check_service_installed(cluster, service)
+        check_service_running(cluster, service)
+        measurements, env_name = influxdb_client.check_influxdb_online()
+        assert measurements and env_name
+
+    def test_influxdb_relay_installed(self, cluster):
+        """Smoke test that checks basic features of InfluxDb.
+
+        Scenario:
+            1. Check InfluxDB relay package is installed
+            2. Check InfluxDB relay is up and running
+
+        Duration 1m
+        """
+        service = "influxdb-relay"
+        check_service_installed(cluster, service)
+        check_service_running(cluster, service)


### PR DESCRIPTION
* Add smoke test to check influxdb:
  package installed (from legacy)
  process is running (from legacy)
* fix config name for infuxdb in client/fixture.py
* change query to show tag values from  cpu_usage_idle with key = host
  in influx_api/get_environment_name()
* Add smoke test to check package/service inflixdb_relay